### PR TITLE
JPT-36 - Refactor Camera

### DIFF
--- a/Source/Graphics/Camera.cpp
+++ b/Source/Graphics/Camera.cpp
@@ -30,9 +30,9 @@ namespace jpt
         EventManager::GetInstance().Register<Event_Mouse_Scroll>(this, &Camera::OnMouseScroll);
 
         // Init position and rotation
-        m_forward = (Vec3(0.0f) - m_position).Normalized();
-        m_pitch = Asin(m_forward.y);
-        m_yaw   = Atan2(m_forward.x, m_forward.z);
+        m_forward = (Vec3(0.0f) - m_worldPos).Normalized();
+        m_pitch   = Asin(m_forward.y);
+        m_yaw     = Atan2(m_forward.x, m_forward.z);
 
         return true;
     }
@@ -41,10 +41,8 @@ namespace jpt
     {
         const Vec3 right = Vec3::Cross(m_forward, Vec3::Up());
 
-        m_position += m_forward * m_move.z * kMoveSpeed * deltaSeconds;
-        m_position +=     right * m_move.x * kMoveSpeed * deltaSeconds;
-
-        m_matrix = Matrix44::LookAt(m_position, m_position + m_forward);
+        m_worldPos += m_forward * m_mover.y * kMoveSpeed * deltaSeconds;
+        m_worldPos +=     right * m_mover.x * kMoveSpeed * deltaSeconds;
     }
 
     void Camera::OnKey(const Event_Key& eventKey)
@@ -57,12 +55,12 @@ namespace jpt
         {
         case Input::Key::W:
         case Input::Key::S:
-            m_move.z = keyDown ? (key == Input::Key::W ? 1.0f : -1.0f) : 0.0f;
+            m_mover.y = keyDown ? (key == Input::Key::W ? 1.0f : -1.0f) : 0.0f;
             break;
 
         case Input::Key::D:
         case Input::Key::A:
-            m_move.x = keyDown ? (key == Input::Key::D ? 1.0f : -1.0f) : 0.0f;
+            m_mover.x = keyDown ? (key == Input::Key::D ? 1.0f : -1.0f) : 0.0f;
             break;
         }
     }
@@ -75,12 +73,12 @@ namespace jpt
         // Right mouse button. FPS camera rotation
         if (button == Input::MouseButton::Right)
         {
-            m_mouseMode = MouseMode::PitchYaw;
+            m_mouseMode = MouseMode::Orbit;
         }
         // Wheel button. Move camera up/down and left/right
         else if (button == Input::MouseButton::Wheel)
         {
-            m_mouseMode = MouseMode::XY;
+            m_mouseMode = MouseMode::Pan;
         }
         else
         {
@@ -121,7 +119,7 @@ namespace jpt
 
         switch (m_mouseMode)
         {
-            case MouseMode::PitchYaw:
+            case MouseMode::Orbit:
             {
                 // Update the yaw and pitch relative to the mouse movement
                 m_pitch += dy * kSensitivity;
@@ -131,7 +129,7 @@ namespace jpt
                 m_pitch = Clamp(m_pitch, -kPitchLimit, kPitchLimit);
                 m_yaw   = Modf(m_yaw, TwoPi);
 
-                // Calculate the updated forward vector
+                // Calculate the new forward vector
                 m_forward.x = Cos(m_pitch) * Sin(m_yaw);
                 m_forward.y = Sin(m_pitch);
                 m_forward.z = Cos(m_pitch) * Cos(m_yaw);
@@ -139,11 +137,11 @@ namespace jpt
 
                 break;
             }
-            case MouseMode::XY:
+            case MouseMode::Pan:
             {
                 // Move the camera up/down and left/right
-                m_position += Vec3::Cross(Vec3::Up(), m_forward) * dx * kSensitivity;
-                m_position += Vec3::Up() * dy * kSensitivity;
+                m_worldPos += Vec3::Cross(Vec3::Up(), m_forward) * dx * kSensitivity;
+                m_worldPos += Vec3::Up() * dy * kSensitivity;
 
                 break;
             }
@@ -162,6 +160,16 @@ namespace jpt
     {
         const double y = eventMouseScroll.GetY();
 
-        m_position += m_forward * static_cast<Precision>(y) * kScrollSpeed;
+        m_worldPos += m_forward * static_cast<Precision>(y) * kScrollSpeed;
+    }
+
+    Matrix44 Camera::CalcMatrix() const
+    {
+        return Matrix44::LookAt(m_worldPos, m_worldPos + m_forward);
+    }
+
+    Vec3 Camera::GetForward() const
+    {
+        return m_forward;
     }
 }

--- a/Source/Graphics/Camera.cppm
+++ b/Source/Graphics/Camera.cppm
@@ -21,25 +21,30 @@ export namespace jpt
     class Camera
     {
     private:
-        enum class MouseMode
+        enum class MouseMode : uint8
         {
-            PitchYaw,
-            XY,
+            Pan,    // Horizontal/Vertical movement
+            Orbit,  // Rotate
         };
 
     private:
-        Matrix44 m_matrix;
-        Vec3 m_move;
+        // Position and Rotation
+        Vec3 m_worldPos   = Vec3(2.0f, 2.0f, 2.0f);   /**< Current world position */
+        Precision m_pitch = 0.0f;   /**< (-Pi/2, Pi/2) */
+        Precision m_yaw   = 0.0f;   /**< (-Pi, Pi) */
 
-        Vec3 m_position = Vec3(2.0f, 2.0f, 2.0f);
-        Vec3 m_forward;
+        // Updaters with delta time
+        Vec2 m_mover;    /**< x = left/right, y = forward/backward */
 
-        // Mouse control
+        // Current window the camera is controlling. TODO: Support multiple windows
         Window* m_pWindow = nullptr;
-        Vec2i m_lockMousePos = Vec2i(Constants<int32>::kMax);
-        MouseMode m_mouseMode = MouseMode::XY;
-        float m_pitch = 0.0f;
-        float m_yaw = 0.0f;
+
+        // Controls
+        Vec2i m_lockMousePos  = Vec2i(Constants<int32>::kMax);
+        MouseMode m_mouseMode = MouseMode::Pan;
+
+        // Cached
+        Vec3 m_forward;  /**< Current heading direction, normalized */
 
     public:
         bool Init();
@@ -51,6 +56,7 @@ export namespace jpt
         void OnMouseScroll(const Event_Mouse_Scroll& eventMouseScroll);
 
     public:
-        const Matrix44& GetMatrix() const { return m_matrix; }
+        Matrix44 CalcMatrix() const;
+        Vec3 GetForward() const;
     };
 }

--- a/Source/Graphics/Vulkan/Vulkan_WindowResources.cpp
+++ b/Source/Graphics/Vulkan/Vulkan_WindowResources.cpp
@@ -377,7 +377,7 @@ namespace jpt::Vulkan
     {
         Uniform_MVP mvp = {};
 
-        mvp.view = GetVkRenderer()->GetCamera().GetMatrix();
+        mvp.view = GetVkRenderer()->GetCamera().CalcMatrix();
 
         mvp.proj = Matrix44::Perspective(ToRadians(45.0f), m_pOwner->GetAspectRatio(), 0.1f, 100.0f);
         mvp.proj[1][1] *= -1;


### PR DESCRIPTION
- Reduced Camera class size from 136 bytes to 64 bytes, by deleting a member variable `Matrix44 m_matrix`
- Kept forward as cached to reduce runtime performance cost
- Renamed variables to more meaningful ones. like m_position -> m_worldPos, m_move -> m_mover