### PR TITLE
JPT-68: Benchmark memcpy and memmove optimizations

### DIFF
--- a/Projects/Benchmarks/Source/Core/Benchmarks_Core.cppm
+++ b/Projects/Benchmarks/Source/Core/Benchmarks_Core.cppm
@@ -19,6 +19,9 @@ import Benchmarks_String;
 // Math
 import Benchmarks_Math;
 
+// Minimal
+import Benchmarks_Utilities;
+
 export void RunBenchmarks_Core(jpt::BenchmarksReporter& reporter)
 {
     /** Benchmark Functions */
@@ -28,11 +31,14 @@ export void RunBenchmarks_Core(jpt::BenchmarksReporter& reporter)
     //RunBenchmarks_HashMap(reporter);
 
     // Functional
-    RunBenchmarks_Function(reporter);
+    //RunBenchmarks_Function(reporter);
 
     // Strings
     //RunBenchmarks_String(reporter);
 
     // Math
     //RunBenchmarks_Math(reporter);
+
+    // Minimal
+    RunBenchmarks_Utilities(reporter);
 }

--- a/Projects/Benchmarks/Source/Core/Minimal/Benchmarks_Utilities.cppm
+++ b/Projects/Benchmarks/Source/Core/Minimal/Benchmarks_Utilities.cppm
@@ -1,0 +1,71 @@
+// Copyright Jupiter Technologies, Inc. All Rights Reserved.
+
+module;
+
+#include "Core/Memory/Memory.h"
+#include "Core/Validation/Assert.h"
+#include "Debugging/Logger.h"
+#include "Profiling/TimingProfiler.h"
+
+#include <memory>
+
+export module Benchmarks_Utilities;
+
+import jpt.BenchmarksReporter;
+import jpt.TypeDefs;
+import jpt.Byte;
+
+constexpr size_t kCount = 1000;
+constexpr size_t kSize = 1024 * 1024; // 1 MB
+jpt::Byte* g_pSrc = nullptr;
+jpt::Byte* g_pDest = nullptr;
+jpt::Byte* g_pBuffer = nullptr;
+
+void jptMemcpy(jpt::BenchmarksReporter& reporter)
+{
+    reporter.Profile("Utilities", "jpt::MemCpy", kCount, [&]()
+        {
+            jpt::MemCpy(g_pDest, g_pSrc, kSize);
+        });
+}
+
+void stdMemcpy(jpt::BenchmarksReporter& reporter)
+{
+    reporter.Profile("Utilities", "std::memcpy", kCount, [&]()
+        {
+            std::memcpy(g_pDest, g_pSrc, kSize);
+        });
+}
+
+void jptMemMove(jpt::BenchmarksReporter& reporter)
+{
+    reporter.Profile("Utilities", "jpt::MemMove", kCount, [&]()
+        {
+            jpt::MemMove(g_pBuffer + 256, g_pBuffer, kSize); // Overlapping regions
+        });
+}
+
+void stdMemMove(jpt::BenchmarksReporter& reporter)
+{
+    reporter.Profile("Utilities", "std::memmove", kCount, [&]()
+        {
+            std::memmove(g_pBuffer + 256, g_pBuffer, kSize); // Overlapping regions
+        });
+}
+
+export void RunBenchmarks_Utilities(jpt::BenchmarksReporter& reporter)
+{
+    g_pSrc = new jpt::Byte[kSize];
+    g_pDest = new jpt::Byte[kSize];
+    g_pBuffer = new jpt::Byte[kSize + 512]; // Extra space for overlap
+
+    jptMemcpy(reporter);
+    stdMemcpy(reporter);
+
+    jptMemMove(reporter);
+    stdMemMove(reporter);
+
+    JPT_DELETE(g_pSrc);
+    JPT_DELETE(g_pDest);
+    JPT_DELETE(g_pBuffer);
+}

--- a/Projects/Benchmarks/Source/Core/Strings/Benchmarks_String.cppm
+++ b/Projects/Benchmarks/Source/Core/Strings/Benchmarks_String.cppm
@@ -22,7 +22,7 @@ void Find(jpt::BenchmarksReporter& reporter)
         {
             jpt::String str = "Hello Jupiter World";
             JPT_ASSERT(str.Find("Jupiter") == 6);
-            JPT_ASSERT(str.Find("NonExist") == jpt::npos);
+            JPT_ASSERT(str.Find("NonExist") == kInvalidIndex);
         });
 }
 

--- a/Source/Core/Minimal/Utilities.cppm
+++ b/Source/Core/Minimal/Utilities.cppm
@@ -59,36 +59,12 @@ export namespace jpt
 
     void MemCpy(void* pDestination, const void* pSource, size_t sizeInBytes)
     {
-        unsigned char* pDst = static_cast<unsigned char*>(pDestination);
-        const unsigned char* pSrc = static_cast<const unsigned char*>(pSource);
-
-        for (size_t i = 0; i < sizeInBytes; ++i)
-        {
-            pDst[i] = pSrc[i];
-        }
+        std::memcpy(pDestination, pSource, sizeInBytes);
     }
 
     void MemMove(void* pDestination, const void* pSource, size_t sizeInBytes)
     {
-        unsigned char* pDst = static_cast<unsigned char*>(pDestination);
-        const unsigned char* pSrc = static_cast<const unsigned char*>(pSource);
-
-        // If the destination is before the source, copy from the beginning
-        if (pDst < pSrc)
-        {
-            for (size_t i = 0; i < sizeInBytes; ++i)
-            {
-                pDst[i] = pSrc[i];
-            }
-        }
-        // If the destination is after the source, copy from the end to avoid overwriting
-        else
-        {
-            for (size_t i = sizeInBytes; i > 0; --i)
-            {
-                pDst[i - 1] = pSrc[i - 1];
-            }
-        }
+        std::memmove(pDestination, pSource, sizeInBytes);
     }
 }
 


### PR DESCRIPTION
Benchmark result:
..\Source\Core\Minimal\Benchmarks_Utilities.cppm(22):      [Log] TimingProfiler: Benchmarks_Utilities::jptMemcpy took 193.388702 ms
..\Source\Core\Minimal\Benchmarks_Utilities.cppm(42):      [Log] TimingProfiler: Benchmarks_Utilities::stdMemcpy took 14.597900 ms
..\Source\Core\Minimal\Benchmarks_Utilities.cppm(59):      [Log] TimingProfiler: Benchmarks_Utilities::jptMemMove took 192.119110 ms
..\Source\Core\Minimal\Benchmarks_Utilities.cppm(75):      [Log] TimingProfiler: Benchmarks_Utilities::stdMemMove took 12.355400 ms

Thus switching to std::memcpy and std::memmove