### PR TITLE
JPT-59  - Refactor JPT_ASSERT, JPT_VERIFY, JPT_ENSURE

### DIFF
--- a/Projects/UnitTests/Config/ProjectSettings.json
+++ b/Projects/UnitTests/Config/ProjectSettings.json
@@ -1,3 +1,2 @@
 {
-    "VSyncMode": 3
 }

--- a/Projects/UnitTests/Config/ProjectSettings.json
+++ b/Projects/UnitTests/Config/ProjectSettings.json
@@ -1,6 +1,3 @@
 {
-    "windowWidth": 600,
-    "targetFPS": 60.000,
-    "windowHeight": 600,
     "VSyncMode": 3
 }

--- a/Projects/UnitTests/Source/Core/Containers/UnitTests_Deque.cppm
+++ b/Projects/UnitTests/Source/Core/Containers/UnitTests_Deque.cppm
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_Deque;
 

--- a/Projects/UnitTests/Source/Core/Containers/UnitTests_Graph.cppm
+++ b/Projects/UnitTests/Source/Core/Containers/UnitTests_Graph.cppm
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_Graph;
 

--- a/Projects/UnitTests/Source/Core/Containers/UnitTests_Heap.cppm
+++ b/Projects/UnitTests/Source/Core/Containers/UnitTests_Heap.cppm
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <queue>
 #include <time.h>

--- a/Projects/UnitTests/Source/Core/Containers/UnitTests_SortedSet.cppm
+++ b/Projects/UnitTests/Source/Core/Containers/UnitTests_SortedSet.cppm
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_SortedSet;
 

--- a/Projects/UnitTests/Source/Core/Math/UnitTests_Line3.cppm
+++ b/Projects/UnitTests/Source/Core/Math/UnitTests_Line3.cppm
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_Line3;
 

--- a/Projects/UnitTests/Source/Core/Minimal/UnitTests_TypeTraits.cppm
+++ b/Projects/UnitTests/Source/Core/Minimal/UnitTests_TypeTraits.cppm
@@ -135,10 +135,18 @@ bool UnitTests_AreSameType()
 {
     bool value = false;
 
+    
+
     value = jpt::AreSameType<int32, int32>;
     JPT_ENSURE(value);
 
+    value = jpt::AreSameType<int32, const int32>;
+    JPT_ENSURE(!value);
+
     value = jpt::AreSameType<int32, int32&>;
+    JPT_ENSURE(!value);
+
+    value = jpt::AreSameType<int32, const int32&>;
     JPT_ENSURE(!value);
 
     value = jpt::AreSameType<int32&, int32&>;

--- a/Projects/UnitTests/Source/Core/Strings/UnitTests_StringHelpers.cppm
+++ b/Projects/UnitTests/Source/Core/Strings/UnitTests_StringHelpers.cppm
@@ -137,9 +137,8 @@ bool RunUnitTests_StringUtils_WStrToCStr()
 
 bool UnitTests_IsSpace()
 {
-    JPT_ENSURE(' ');
-    JPT_ENSURE('\u00A0');
-    JPT_ENSURE(' ');
+    JPT_ENSURE(jpt::IsSpace(' '));
+    JPT_ENSURE(jpt::IsSpace('\u00A0'));
 
     return true;
 }

--- a/Projects/UnitTests/Source/Core/Types/UnitTests_Enum.cppm
+++ b/Projects/UnitTests/Source/Core/Types/UnitTests_Enum.cppm
@@ -4,8 +4,6 @@ module;
 
 #include "Core/Minimal/CoreHeaders.h"
 
-#include "Core/Types/Enum.h"
-
 export module UnitTests_Enum;
 
 import UnitTests_Enum_Global;
@@ -73,16 +71,21 @@ bool UnitTests_Enum_NonSequence()
     for (const auto& [key, value] : fruit) // Structure binding is available too
     {
         if (key == 5)
+        {
             JPT_ENSURE(value == "Apple");
-
+        }
         if (key == 6)
+        {
             JPT_ENSURE(value == "Banana");
-
+        }
         if (key == 9)
+        {
             JPT_ENSURE(value == "Orange");
-
+        }
         if (key == 10)
+        {
             JPT_ENSURE(value == "Grape");
+        }
     }
 
     // Assigning with different sized integer

--- a/Projects/UnitTests/Source/Frameworks/EventSystem/UnitTests_EventSystem.cppm
+++ b/Projects/UnitTests/Source/Frameworks/EventSystem/UnitTests_EventSystem.cppm
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_EventSystem;
 

--- a/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_BestMeetingNode.cppm
+++ b/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_BestMeetingNode.cppm
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_Coding_BestMeetingNode;
 

--- a/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_BestSeat.cppm
+++ b/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_BestSeat.cppm
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_Coding_BestSeat;
 

--- a/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_KthLargestElement.cppm
+++ b/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_KthLargestElement.cppm
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_Coding_KthLargestElement;
 

--- a/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_MinUniqueSubArray.cppm
+++ b/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_MinUniqueSubArray.cppm
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module UnitTests_Coding_MinUniqueSubArray;
 

--- a/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_RotateBits.cppm
+++ b/Projects/UnitTests/Source/Scratch/Coding/UnitTests_Coding_RotateBits.cppm
@@ -1,7 +1,6 @@
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <memory>
 

--- a/Source/Applications/Framework/Framework.cpp
+++ b/Source/Applications/Framework/Framework.cpp
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Debugging/Logger.h"
-#include "Core/Minimal/Utilities.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 module jpt.Framework;
 

--- a/Source/Applications/Framework/Framework_GLFW.cpp
+++ b/Source/Applications/Framework/Framework_GLFW.cpp
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <GLFW/glfw3.h>
 

--- a/Source/Applications/Framework/Framework_Win32.cpp
+++ b/Source/Applications/Framework/Framework_Win32.cpp
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/Source/Core/Minimal/Utilities.h
+++ b/Source/Core/Minimal/Utilities.h
@@ -16,28 +16,6 @@ import jpt.Utilities;
 
 #pragma endregion
 
-#pragma region Verification
-
-/**< Return, with Error logging */
-#define JPT_VERIFY(condition, returnValue, ...)  \
-    if (!(condition))                            \
-    {                                            \
-        if (JPT_HAS_ARGS(__VA_ARGS__))           \
-        {                                        \
-            JPT_ERROR("%s", __VA_ARGS__);        \
-        }                                        \
-        else                                     \
-        {                                        \
-            JPT_ERROR("Failed: %s", #condition); \
-        }                                        \
-        return returnValue;                      \
-    }                                             
-                                                 
-#define JPT_ENSURE(condition, ...)               \
-    JPT_VERIFY(condition, false, __VA_ARGS__)    
-
-#pragma endregion
-
 #pragma region VA_ARGS
 
 /** @return true if a macro's variadic arguments has passed in parameters. false if it's empty

--- a/Source/Core/Validation/Assert.h
+++ b/Source/Core/Validation/Assert.h
@@ -48,7 +48,7 @@ namespace jpt
             } while(false)
 }
 #else
-    #define JPT_ASSERT(expression, ...) static_cast<void>(expression)
+    #define JPT_ASSERT(expression, ...) static_cast<void>(0)
 
 #endif // ASSERT_ENABLED
 

--- a/Source/Core/Validation/Assert.h
+++ b/Source/Core/Validation/Assert.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#define ASSERT_ENABLED (IS_CONFIG_DEBUG || IS_CONFIG_DEV)
+#define ASSERT_ENABLED (!IS_CONFIG_RELEASE)
 
 #if ASSERT_ENABLED
 
@@ -48,6 +48,6 @@ namespace jpt
             } while(false)
 }
 #else
-    #define JPT_ASSERT(expression, ...) static_cast<void>(expression)
+    #define JPT_ASSERT(expression, ...) static_cast<void>(0)
 
 #endif // ASSERT_ENABLED

--- a/Source/Core/Validation/Assert.h
+++ b/Source/Core/Validation/Assert.h
@@ -27,16 +27,16 @@ namespace jpt
     #error "DebugBreak not implemented for this platform"
 #endif        
 
-    /** Assert with error message logging if Debug mode, do nothing if not Debugging
-        @param expression: A boolean expression to assert true
-        @param ...:           Error messages if the expression went false
+    /** Assert with error message logging if not Release build, do nothing if Release build
+        @param expression: A boolean expression to assert
+        @param ...:        Error messages if the expression went false
 
         Example:
         int a = 10;
         int b = 11;
         JPT_ASSERT(a == 9 && b == 10);
         JPT_ASSERT(a == 9 && b == 10, "expected 9 and 10");
-        JPT_ASSERT(a == 9 && b == 10, "expected 9 and 10, received %d and %d", a, b);*/
+        JPT_ASSERT(a == 9 && b == 10, "expected 9 and 10, received %d and %d", a, b); */
 #define JPT_ASSERT(expression, ...)                                                       \
             do                                                                            \
             {                                                                             \
@@ -48,6 +48,29 @@ namespace jpt
             } while(false)
 }
 #else
-    #define JPT_ASSERT(expression, ...) static_cast<void>(0)
+    #define JPT_ASSERT(expression, ...) static_cast<void>(expression)
 
 #endif // ASSERT_ENABLED
+
+/**< Verify condition with Error log. Always executed regardless build config */
+#define JPT_VERIFY(condition, ...)               \
+    if (!(condition))                            \
+    {                                            \
+        if (JPT_HAS_ARGS(__VA_ARGS__))           \
+        {                                        \
+            JPT_ERROR("%s", __VA_ARGS__);        \
+        }                                        \
+        else                                     \
+        {                                        \
+            JPT_ERROR("Failed: %s", #condition); \
+        }                                        \
+    }                                             
+                                                 
+/** Ensure condition with Error log and early return false if failed. */
+#define JPT_ENSURE(condition, ...)                                            \
+    bool JPT_CONCAT(ensure, __LINE__) = (condition);                          \
+    JPT_VERIFY(JPT_CONCAT(ensure, __LINE__), #condition##" - "##__VA_ARGS__); \
+    if (!JPT_CONCAT(ensure, __LINE__))                                        \
+    {                                                                         \
+        return false;                                                         \
+    }

--- a/Source/Debugging/AssertImpl.cpp
+++ b/Source/Debugging/AssertImpl.cpp
@@ -12,11 +12,11 @@ module;
 
 module jpt.AssertImpl;
 
+#if ASSERT_ENABLED
 import jpt.String;
 
 namespace jpt
 {
-#if ASSERT_ENABLED
     void locAssertCallback(int line, const char* file, const char* expression, const char* message)
     {
         String messageStr(expression);
@@ -32,13 +32,11 @@ namespace jpt
         MessageBoxA(nullptr, messageStr.ConstBuffer(), "Assertion Failed", MB_ABORTRETRYIGNORE);
 #endif
     }
-#endif
 
     bool AssertImpl::PreInit()
     {
-#if ASSERT_ENABLED
         g_AssertCallback = locAssertCallback;
-#endif
         return true;
     }
 }
+#endif

--- a/Source/Debugging/AssertImpl.cppm
+++ b/Source/Debugging/AssertImpl.cppm
@@ -1,7 +1,12 @@
 // Copyright Jupiter Technologies, Inc. All Rights Reserved.
 
+module;
+
+#include "Core/Validation/Assert.h"
+
 export module jpt.AssertImpl;
 
+#if ASSERT_ENABLED
 export namespace jpt
 {
     class AssertImpl
@@ -10,3 +15,4 @@ export namespace jpt
         bool PreInit();
     };
 }
+#endif

--- a/Source/Debugging/Debugger.cpp
+++ b/Source/Debugging/Debugger.cpp
@@ -2,6 +2,8 @@
 
 module; 
 
+#include "Core/Validation/Assert.h"
+
 #if IS_PLATFORM_WINDOWS
     #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
@@ -15,7 +17,9 @@ namespace jpt
     {
         bool success = true;
 
+#if ASSERT_ENABLED
         success &= m_assertImpl.PreInit();
+#endif
 
         return success;
     }

--- a/Source/Debugging/Debugger.cppm
+++ b/Source/Debugging/Debugger.cppm
@@ -3,6 +3,7 @@
 module;
 
 #include "Core/Minimal/Utilities.h"
+#include "Core/Validation/Assert.h"
 
 export module jpt.Debugger;
 
@@ -15,7 +16,9 @@ export namespace jpt
         JPT_DECLARE_SINGLETON(Debugger);
 
     private:
+#if ASSERT_ENABLED
         AssertImpl m_assertImpl;
+#endif
 
     public:
         bool PreInit();

--- a/Source/Graphics/DX12/DX12_Device.cppm
+++ b/Source/Graphics/DX12/DX12_Device.cppm
@@ -2,7 +2,7 @@
 
 module;
 
-#include <Core/Validation/Assert.h>
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <d3d12.h>
 #include <dxgi1_6.h>
@@ -49,14 +49,14 @@ export namespace jpt::DX12
         if (useWarpDevice)
         {
             Microsoft::WRL::ComPtr<IDXGIAdapter> warpAdapter;
-            JPT_ASSERT(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)) == S_OK);
-            JPT_ASSERT(D3D12CreateDevice(warpAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_device)) == S_OK);
+            JPT_VERIFY(factory->EnumWarpAdapter(IID_PPV_ARGS(&warpAdapter)) == S_OK);
+            JPT_VERIFY(D3D12CreateDevice(warpAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_device)) == S_OK);
         }
         else
         {
             Microsoft::WRL::ComPtr<IDXGIAdapter1> hardwareAdapter;
             GetHardwareAdapter(factory.Get(), &hardwareAdapter);
-            JPT_ASSERT(D3D12CreateDevice(hardwareAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_device)) == S_OK);
+            JPT_VERIFY(D3D12CreateDevice(hardwareAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_device)) == S_OK);
         }
 
         m_rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
@@ -66,8 +66,7 @@ export namespace jpt::DX12
     Microsoft::WRL::ComPtr<ID3D12CommandAllocator> Device::CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE type) const
     {
         Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator;
-        [[maybe_unused]] HRESULT hr = m_device->CreateCommandAllocator(type, IID_PPV_ARGS(&commandAllocator));
-        JPT_ASSERT(hr == S_OK);
+        JPT_VERIFY(m_device->CreateCommandAllocator(type, IID_PPV_ARGS(&commandAllocator)) == S_OK);
         return commandAllocator;
     }
 
@@ -78,8 +77,7 @@ export namespace jpt::DX12
         queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
         Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue;
-        [[maybe_unused]] HRESULT hr = m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&commandQueue));
-        JPT_ASSERT(hr == S_OK);
+        JPT_VERIFY(m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&commandQueue)) == S_OK);
 
         return commandQueue;
     }
@@ -92,8 +90,8 @@ export namespace jpt::DX12
 
         Microsoft::WRL::ComPtr<ID3DBlob> signature;
         Microsoft::WRL::ComPtr<ID3DBlob> error;
-        JPT_ASSERT(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error) == S_OK);
-        JPT_ASSERT(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&rootSignature)) == S_OK);
+        JPT_VERIFY(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error) == S_OK);
+        JPT_VERIFY(m_device->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&rootSignature)) == S_OK);
 
         return rootSignature;
     }
@@ -107,7 +105,7 @@ export namespace jpt::DX12
         rtvHeapDesc.NumDescriptors = kMaxFramesInFlight;
         rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
         rtvHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        JPT_ASSERT(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&rtvHeap)) == S_OK);
+        JPT_VERIFY(m_device->CreateDescriptorHeap(&rtvHeapDesc, IID_PPV_ARGS(&rtvHeap)) == S_OK);
 
         return RTVHeap(rtvHeap);
     }

--- a/Source/Graphics/DX12/DX12_Device.cppm
+++ b/Source/Graphics/DX12/DX12_Device.cppm
@@ -66,7 +66,7 @@ export namespace jpt::DX12
     Microsoft::WRL::ComPtr<ID3D12CommandAllocator> Device::CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE type) const
     {
         Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocator;
-        HRESULT hr = m_device->CreateCommandAllocator(type, IID_PPV_ARGS(&commandAllocator));
+        [[maybe_unused]] HRESULT hr = m_device->CreateCommandAllocator(type, IID_PPV_ARGS(&commandAllocator));
         JPT_ASSERT(hr == S_OK);
         return commandAllocator;
     }
@@ -78,7 +78,7 @@ export namespace jpt::DX12
         queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
 
         Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue;
-        HRESULT hr = m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&commandQueue));
+        [[maybe_unused]] HRESULT hr = m_device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&commandQueue));
         JPT_ASSERT(hr == S_OK);
 
         return commandQueue;

--- a/Source/Graphics/DX12/DX12_SwapChain.cppm
+++ b/Source/Graphics/DX12/DX12_SwapChain.cppm
@@ -2,7 +2,7 @@
 
 module;
 
-#include <Core/Validation/Assert.h>
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <d3d12.h>
 #include <dxgi1_6.h>
@@ -45,7 +45,7 @@ export namespace jpt::DX12
         swapChainDesc.SampleDesc.Count = 1;
 
         Microsoft::WRL::ComPtr<IDXGISwapChain1> swapChain;
-        JPT_ASSERT(factory->CreateSwapChainForHwnd(
+        JPT_VERIFY(factory->CreateSwapChainForHwnd(
             commandQueue.Get(),        // Swap chain needs the queue so that it can force a flush on it.
             hwnd,
             &swapChainDesc,

--- a/Source/Graphics/DX12/DX12_SyncObjects.cppm
+++ b/Source/Graphics/DX12/DX12_SyncObjects.cppm
@@ -2,8 +2,7 @@
 
 module;
 
-#include <Core/Validation/Assert.h>
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <d3d12.h>
 #include <dxgi1_6.h>
@@ -37,7 +36,7 @@ export namespace jpt::DX12
 
     bool SyncObjects::Init(Microsoft::WRL::ComPtr<ID3D12Device> device, Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue, const SwapChain& swapChain, size_t& frameIndex)
     {
-        JPT_ASSERT(device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)) == S_OK);
+        JPT_VERIFY(device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)) == S_OK);
         m_fenceValue = 1;
 
         // Create an event handle to use for frame synchronization.
@@ -70,13 +69,13 @@ export namespace jpt::DX12
         
         // Signal and increment the fence value.
         const UINT64 fence = m_fenceValue;
-        JPT_ASSERT(commandQueue->Signal(m_fence.Get(), fence) == S_OK);
+        JPT_VERIFY(commandQueue->Signal(m_fence.Get(), fence) == S_OK);
         ++m_fenceValue;
 
         // Wait until the previous frame is finished.
         if (m_fence->GetCompletedValue() < fence)
         {
-            JPT_ASSERT(m_fence->SetEventOnCompletion(fence, m_fenceEvent) == S_OK);
+            JPT_VERIFY(m_fence->SetEventOnCompletion(fence, m_fenceEvent) == S_OK);
             WaitForSingleObject(m_fenceEvent, INFINITE);
         }
 

--- a/Source/Graphics/DX12/DX12_WindowResources.cppm
+++ b/Source/Graphics/DX12/DX12_WindowResources.cppm
@@ -2,7 +2,7 @@
 
 module;
 
-#include <Core/Validation/Assert.h>
+#include <Core/Minimal/CoreHeaders.h>
 
 #include <d3d12.h>
 #include <dxgi1_6.h>
@@ -87,7 +87,7 @@ export namespace jpt::DX12
         JPT_ASSERT(win32Window, "Window is not of type Window_Win32");
 
         const HWND hwnd = win32Window->GetHWND();
-        JPT_ASSERT(m_swapChain.Init(m_pOwner->GetFrameSize(), hwnd, factory, commandQueue));
+        JPT_VERIFY(m_swapChain.Init(m_pOwner->GetFrameSize(), hwnd, factory, commandQueue));
 
         m_currentFrame = m_swapChain.GetCurrentBackBufferIndex();
 
@@ -107,7 +107,7 @@ export namespace jpt::DX12
         // Create a RTV for each frame.
         for (UINT n = 0; n < kMaxFramesInFlight; n++)
         {
-            JPT_ASSERT(m_swapChain.GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])) == S_OK);
+            JPT_VERIFY(m_swapChain.GetBuffer(n, IID_PPV_ARGS(&m_renderTargets[n])) == S_OK);
             device.CreateRenderTargetView(m_renderTargets[n].Get(), nullptr, rtvHandle);
             rtvHandle.Offset(1, device.GetRTVDescriptorSize());
         }

--- a/Source/Graphics/DX12/Renderer_DX12.cppm
+++ b/Source/Graphics/DX12/Renderer_DX12.cppm
@@ -171,7 +171,7 @@ export namespace jpt
         m_commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
 
         // Present the frame.
-        JPT_ASSERT(resources.GetSwapChain().Present(1, 0) == S_OK);
+        JPT_VERIFY(resources.GetSwapChain().Present(1, 0) == S_OK);
 
         resources.WaitForPreviousFrame(m_commandQueue);
     }
@@ -184,12 +184,12 @@ export namespace jpt
         // Command list allocators can only be reset when the associated 
         // command lists have finished execution on the GPU; apps should use 
         // fences to determine GPU execution progress.
-        JPT_ASSERT(m_commandAllocator->Reset() == S_OK);
+        JPT_VERIFY(m_commandAllocator->Reset() == S_OK);
 
         // However, when ExecuteCommandList() is called on a particular command 
         // list, that command list can then be reset at any time and must be before 
         // re-recording.
-        JPT_ASSERT(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()) == S_OK);
+        JPT_VERIFY(m_commandList->Reset(m_commandAllocator.Get(), m_pipelineState.Get()) == S_OK);
 
         // Set necessary state.
         m_commandList->SetGraphicsRootSignature(m_rootSignature.Get());
@@ -214,7 +214,7 @@ export namespace jpt
         auto barrier2 = CD3DX12_RESOURCE_BARRIER::Transition(renderTarget.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
         m_commandList->ResourceBarrier(1, &barrier2);
 
-        JPT_ASSERT(m_commandList->Close() == S_OK);
+        JPT_VERIFY(m_commandList->Close() == S_OK);
     }
 
     void Renderer_DX12::CompileShaders()
@@ -230,8 +230,8 @@ export namespace jpt
 #else
         UINT compileFlags = 0;
 #endif
-        JPT_ASSERT(D3DCompileFromFile(shadersPath.GetString<wchar_t>().ConstBuffer(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr) == S_OK);
-        JPT_ASSERT(D3DCompileFromFile(shadersPath.GetString<wchar_t>().ConstBuffer(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr) == S_OK);
+        JPT_VERIFY(D3DCompileFromFile(shadersPath.GetString<wchar_t>().ConstBuffer(), nullptr, nullptr, "VSMain", "vs_5_0", compileFlags, 0, &vertexShader, nullptr) == S_OK);
+        JPT_VERIFY(D3DCompileFromFile(shadersPath.GetString<wchar_t>().ConstBuffer(), nullptr, nullptr, "PSMain", "ps_5_0", compileFlags, 0, &pixelShader, nullptr) == S_OK);
 
         // Define the vertex input layout.
         D3D12_INPUT_ELEMENT_DESC inputElementDescs[] =
@@ -255,7 +255,7 @@ export namespace jpt
         psoDesc.NumRenderTargets = 1;
         psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
         psoDesc.SampleDesc.Count = 1;
-        JPT_ASSERT(m_device.Get()->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)) == S_OK);
+        JPT_VERIFY(m_device.Get()->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineState)) == S_OK);
     }
 
     void Renderer_DX12::CreateVertexBuffer(float aspectRatio)
@@ -276,7 +276,7 @@ export namespace jpt
         // code simplicity and because there are very few verts to actually transfer.
         CD3DX12_HEAP_PROPERTIES heapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
         CD3DX12_RESOURCE_DESC vertexBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(vertexBufferSize);
-        JPT_ASSERT(m_device.Get()->CreateCommittedResource(
+        JPT_VERIFY(m_device.Get()->CreateCommittedResource(
             &heapProperties,
             D3D12_HEAP_FLAG_NONE,
             &vertexBufferDesc,
@@ -287,7 +287,7 @@ export namespace jpt
         // Copy the triangle data to the vertex buffer.
         UINT8* pVertexDataBegin;
         CD3DX12_RANGE readRange(0, 0);        // We do not intend to read from this resource on the CPU.
-        JPT_ASSERT(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)) == S_OK);
+        JPT_VERIFY(m_vertexBuffer->Map(0, &readRange, reinterpret_cast<void**>(&pVertexDataBegin)) == S_OK);
         memcpy(pVertexDataBegin, triangleVertices, sizeof(triangleVertices));
         m_vertexBuffer->Unmap(0, nullptr);
 

--- a/Source/Graphics/DX12/Renderer_DX12.cppm
+++ b/Source/Graphics/DX12/Renderer_DX12.cppm
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/Source/Graphics/Renderer.cpp
+++ b/Source/Graphics/Renderer.cpp
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Debugging/Logger.h"
-#include "Core/Minimal/Utilities.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 module jpt.Renderer;
 

--- a/Source/Graphics/Vulkan/Renderer_Vulkan.cpp
+++ b/Source/Graphics/Vulkan/Renderer_Vulkan.cpp
@@ -2,10 +2,7 @@
 
 module;
 
-#include "Core/Memory/Memory.h"
-#include "Core/Minimal/Utilities.h"
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <vulkan/vulkan.h>
 

--- a/Source/Graphics/Vulkan/Vulkan_Pipeline.cpp
+++ b/Source/Graphics/Vulkan/Vulkan_Pipeline.cpp
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Validation/Assert.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <vulkan/vulkan.h>
 
@@ -36,8 +35,8 @@ namespace jpt::Vulkan
         VertexShader  vertexShader;
         PixelShader   pixelShader;
 
-        JPT_ASSERT(vertexShader.Load("_Baked/Jupiter_Common/Shaders/Default_Vert.glsl.spv"));
-        JPT_ASSERT(pixelShader.Load("_Baked/Jupiter_Common/Shaders/Default_Frag.glsl.spv"));
+        JPT_VERIFY(vertexShader.Load("_Baked/Jupiter_Common/Shaders/Default_Vert.glsl.spv"));
+        JPT_VERIFY(pixelShader.Load("_Baked/Jupiter_Common/Shaders/Default_Frag.glsl.spv"));
 
         VkPipelineShaderStageCreateInfo vertexShaderStageInfo = vertexShader.GetStageCreateInfo();
         VkPipelineShaderStageCreateInfo pixelShaderStageInfo  = pixelShader.GetStageCreateInfo();

--- a/Source/Input/RawInput/RawInput_GLFW.cpp
+++ b/Source/Input/RawInput/RawInput_GLFW.cpp
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
-#include "Core/Validation/Assert.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #include <GLFW/glfw3.h>
 

--- a/Source/Input/RawInput/RawInput_Win32.cppm
+++ b/Source/Input/RawInput/RawInput_Win32.cppm
@@ -2,9 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
-#include "Core/Validation/Assert.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 export module jpt.RawInput_Win32;
 

--- a/Source/System/Hardware/HardwareManager.cpp
+++ b/Source/System/Hardware/HardwareManager.cpp
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 module jpt.HardwareManager;
 

--- a/Source/System/Platforms/Platform_Windows.cpp
+++ b/Source/System/Platforms/Platform_Windows.cpp
@@ -2,8 +2,7 @@
 
 module;
 
-#include "Core/Minimal/Utilities.h"
-#include "Debugging/Logger.h"
+#include "Core/Minimal/CoreHeaders.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>


### PR DESCRIPTION
Before: The boundaries weren't clear
- Assert: Halt program and log error message if not release build and condition failed. Execute condition if Release build
- Verify: Early Return void. Always executed
- Ensure: Early Return false. Always executed

After: 
- Assert: Halt program and log error message if not release build and condition failed. Do nothing if Release build
- Verify: log error message if condition failed. Always executed regardless of build config. No early return.
- Ensure: log error message if condition failed. Always executed regardless of build config. Early return